### PR TITLE
fix: top bar element takes full width

### DIFF
--- a/src/components/layout/Dashboard.js
+++ b/src/components/layout/Dashboard.js
@@ -12,7 +12,7 @@ const Container = styled('div')`
 `;
 
 const Headline = styled('div')`
-  max-width: 74rem;
+  width: 100%;
   height: 4rem;
   background-color: #ffffff;
 `;


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2021-12-15 at 9 53 27 AM" src="https://user-images.githubusercontent.com/14043581/146239373-0dd42777-375a-4d52-8a5e-6eabca71641e.png">
