### PR TITLE
fix: using forms on smaller window sizes

### DIFF
--- a/src/components/blocks/Modal.js
+++ b/src/components/blocks/Modal.js
@@ -41,6 +41,10 @@ const ModalContainer = styled('div')`
     css`
       height: fit-content;
       width: fit-content;
+      @media (max-width:866px){
+        width: 100%;
+        height: 100%;
+      }
     `}
 `;
 
@@ -101,6 +105,9 @@ const BodyContainer = styled('div')`
       width: 868px;
       height: 724px;
       overflow: scroll;
+      @media (max-width:868px){
+        width: 100%;
+      }
     `}
 `;
 

--- a/src/pages/Projects/index.js
+++ b/src/pages/Projects/index.js
@@ -46,7 +46,6 @@ const StyledSectionContainer = styled('div')`
   display: flex;
   flex-direction: column;
   height: 100%;
-  position: relative;
 `;
 
 const StyledHeaderContainer = styled('div')`


### PR DESCRIPTION
Smaller Window Size
<img width="1440" alt="Screen Shot 2022-01-11 at 5 52 51 AM" src="https://user-images.githubusercontent.com/14043581/148955350-47281844-f773-4bdf-82fe-d7f52c0e447c.png">

Smaller Window Size With Scroll
<img width="1440" alt="Screen Shot 2022-01-11 at 5 55 47 AM" src="https://user-images.githubusercontent.com/14043581/148955706-9f228119-1fd3-44bd-885a-b82d05d8b68e.png">

