### PR TITLE
fix: added error display on inputs without any

### DIFF
--- a/src/components/forms/CreateCoBenefitsForm.js
+++ b/src/components/forms/CreateCoBenefitsForm.js
@@ -8,6 +8,7 @@ import { setValidationErrors } from '../../utils/validationUtils';
 import {
   StandardInput,
   InputSizeEnum,
+  InputVariantEnum,
   InputStateEnum,
   Divider,
   ModalFormContainerStyle,
@@ -45,14 +46,18 @@ const CreateCoBenefitsForm = ({ value, onChange }) => {
               <ToolTipContainer
                 tooltip={intl.formatMessage({
                   id: 'cobenefits-cobenefit-description',
-                })}
-              >
+                })}>
                 <DescriptionIcon height="14" width="14" />
               </ToolTipContainer>
             </Body>
           </StyledLabelContainer>
           <InputContainer>
             <StandardInput
+              variant={
+                errorCoBenefitsMessage?.cobenefit
+                  ? InputVariantEnum.error
+                  : undefined
+              }
               size={InputSizeEnum.large}
               placeholderText={intl.formatMessage({ id: 'co-benefit' })}
               state={InputStateEnum.default}

--- a/src/components/forms/CreateEstimationsForm.js
+++ b/src/components/forms/CreateEstimationsForm.js
@@ -5,6 +5,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import {
   StandardInput,
   InputSizeEnum,
+  InputVariantEnum,
   InputStateEnum,
   Divider,
   ModalFormContainerStyle,
@@ -48,8 +49,7 @@ const CreateEstimationsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'estimation-period-start-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -78,8 +78,7 @@ const CreateEstimationsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'estimation-period-end-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -108,14 +107,18 @@ const CreateEstimationsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'estimation-unit-count-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorEstimationMessage?.unitCount
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 type="number"
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({

--- a/src/components/forms/CreateLocationsForm.js
+++ b/src/components/forms/CreateLocationsForm.js
@@ -6,6 +6,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import {
   StandardInput,
   InputSizeEnum,
+  InputVariantEnum,
   InputStateEnum,
   Divider,
   ModalFormContainerStyle,
@@ -62,8 +63,7 @@ const CreateLocationsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'locations-country-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -99,8 +99,7 @@ const CreateLocationsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'locations-in-country-region-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -133,14 +132,18 @@ const CreateLocationsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'locations-geographic-identifier-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorLocationMessage?.geographicIdentifier
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({
                   id: 'geographic-identifier',

--- a/src/components/forms/CreateRatingsForm.js
+++ b/src/components/forms/CreateRatingsForm.js
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux';
 import {
   StandardInput,
   InputSizeEnum,
+  InputVariantEnum,
   InputStateEnum,
   Divider,
   ModalFormContainerStyle,
@@ -62,8 +63,7 @@ const CreateRatingsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'ratings-rating-type-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -99,14 +99,18 @@ const CreateRatingsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'ratings-rating-range-highest-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorRatingMessage?.ratingRangeHighest
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({
                   id: 'rating-range-highest',
@@ -133,14 +137,18 @@ const CreateRatingsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'ratings-rating-range-lowest-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorRatingMessage?.ratingRangeLowest
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({
                   id: 'rating-range-lowest',
@@ -169,14 +177,18 @@ const CreateRatingsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'ratings-rating-value-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorRatingMessage?.rating
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({
                   id: 'rating',
@@ -203,14 +215,18 @@ const CreateRatingsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'ratings-rating-report-link-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorRatingMessage?.ratingLink
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({
                   id: 'rating-link',

--- a/src/components/forms/CreateRelatedProjectsForm.js
+++ b/src/components/forms/CreateRelatedProjectsForm.js
@@ -8,6 +8,7 @@ import { setValidationErrors } from '../../utils/validationUtils';
 import {
   StandardInput,
   InputSizeEnum,
+  InputVariantEnum,
   InputStateEnum,
   Divider,
   ModalFormContainerStyle,
@@ -53,14 +54,18 @@ const CreateRelatedProjectsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'related-project-id',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorRelatedProjectMessage?.relatedProjectId
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({
                   id: 'related-project-id',
@@ -87,8 +92,7 @@ const CreateRelatedProjectsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'related-projects-relationship-type-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -121,8 +125,7 @@ const CreateRelatedProjectsForm = ({ value, onChange }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'related-projects-registry-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>

--- a/src/components/forms/ProjectDetailsForm.js
+++ b/src/components/forms/ProjectDetailsForm.js
@@ -8,6 +8,7 @@ import {
   StandardInput,
   InputSizeEnum,
   InputStateEnum,
+  InputVariantEnum,
   ModalFormContainerStyle,
   FormContainerStyle,
   BodyContainer,
@@ -52,8 +53,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-registry-of-origin-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -92,14 +92,18 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-origin-project-id-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorIssuanceMessage?.originProjectId
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({
                   id: 'origin-project-id',
@@ -129,8 +133,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-program-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -166,13 +169,17 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-project-id-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <StandardInput
+              variant={
+                errorIssuanceMessage?.projectId
+                  ? InputVariantEnum.error
+                  : undefined
+              }
               size={InputSizeEnum.large}
               placeholderText={intl.formatMessage({
                 id: 'project-id',
@@ -201,14 +208,18 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-project-name-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorIssuanceMessage?.projectName
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({
                   id: 'project-name',
@@ -238,14 +249,18 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-project-link-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorIssuanceMessage?.projectLink
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({
                   id: 'project-link',
@@ -275,14 +290,18 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-project-developer-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorIssuanceMessage?.projectDeveloper
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({
                   id: 'project-developer',
@@ -312,8 +331,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-sector-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -350,8 +368,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-project-type-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -391,8 +408,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-covered-by-ndc-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -432,14 +448,18 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-ndc-information-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
             </StyledLabelContainer>
             <InputContainer>
               <StandardInput
+                variant={
+                  errorIssuanceMessage?.ndcInformation
+                    ? InputVariantEnum.error
+                    : undefined
+                }
                 size={InputSizeEnum.large}
                 placeholderText={intl.formatMessage({
                   id: 'ndc-information',
@@ -469,8 +489,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-project-status-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -509,8 +528,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-project-status-date-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -542,8 +560,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-unit-metric-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -582,8 +599,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-methodology-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -622,8 +638,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-validation-date-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -655,8 +670,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-validation-body-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>
@@ -695,8 +709,7 @@ const ProjectDetailsForm = ({ projectDetails, setProjectDetails }) => {
                 <ToolTipContainer
                   tooltip={intl.formatMessage({
                     id: 'projects-project-tags-description',
-                  })}
-                >
+                  })}>
                   <DescriptionIcon height="14" width="14" />
                 </ToolTipContainer>
               </Body>


### PR DESCRIPTION
Projects Error Input Display
![Screen Shot 2022-02-28 at 9 55 31 PM (2)](https://user-images.githubusercontent.com/14043581/156113396-1b1cf053-5c02-4474-a992-b60f1949ce6c.png)

Labels Error Input Display
![Screen Shot 2022-02-28 at 9 56 09 PM (2)](https://user-images.githubusercontent.com/14043581/156113437-21e39798-04e4-4a9d-9f55-9fba78706459.png)

Issuance Error Input Display
![Screen Shot 2022-02-28 at 9 56 20 PM (2)](https://user-images.githubusercontent.com/14043581/156113493-b2075769-bafc-4908-87b6-68129815e9e1.png)

Co-Benefits Error Input Display
![Screen Shot 2022-02-28 at 9 56 29 PM (2)](https://user-images.githubusercontent.com/14043581/156113566-5b67fe53-92ed-4978-a262-781023bf586c.png)

Project Locations Error Input Display
![Screen Shot 2022-02-28 at 9 56 39 PM (2)](https://user-images.githubusercontent.com/14043581/156113610-05f30ecc-6467-429a-8f16-85c3a0a17181.png)

Related Projects Error Input Display
![Screen Shot 2022-02-28 at 9 56 51 PM (2)](https://user-images.githubusercontent.com/14043581/156113671-3dd2553b-cc67-484f-adc1-903eee2b4f08.png)

Estimations Error Input Display
![Screen Shot 2022-02-28 at 9 57 08 PM (2)](https://user-images.githubusercontent.com/14043581/156113766-c8656306-3edf-4f72-9ef3-7b2caab619eb.png)

Ratings Error Input Display
![Screen Shot 2022-02-28 at 9 57 20 PM (2)](https://user-images.githubusercontent.com/14043581/156113807-3b42d2f3-4856-4d6c-8d92-db3f6e15f8f6.png)


