### PR TITLE
fix: import date adapter from correct package

### DIFF
--- a/src/components/blocks/DateSelect.js
+++ b/src/components/blocks/DateSelect.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import DateAdapter from '@mui/lab/AdapterDayjs';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import styled, { css, withTheme } from 'styled-components';
 import TextField from '@mui/material/TextField';
@@ -82,7 +82,7 @@ const DateSelect = withTheme(
     onBlur,
     name,
   }) => (
-    <LocalizationProvider dateAdapter={DateAdapter}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DesktopDatePicker
         inputFormat="YYYY-MM-DD"
         mask="____-__-__"

--- a/src/components/blocks/YearSelect.js
+++ b/src/components/blocks/YearSelect.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import DateAdapter from '@mui/lab/AdapterDayjs';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import styled, { css, withTheme } from 'styled-components';
 import TextField from '@mui/material/TextField';
@@ -72,7 +72,7 @@ const StyledTextField = styled(TextField)`
 
 const YearSelect = withTheme(
   ({ size, yearValue, onChange, disabled, variant, onBlur, name }) => (
-    <LocalizationProvider dateAdapter={DateAdapter}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DesktopDatePicker
         inputFormat="YYYY"
         mask="____"


### PR DESCRIPTION
The material UI version updated requiring the date adapter to be imported from a new location. Previously it was imported from labs but since then has made the mainstream package of x-date-pickers.

Without this fix, attempting to use the date picker would cause a fatal error in the ui.