### PR TITLE
fix: hardcoded api host in file download fetch requests

### DIFF
--- a/src/renderer/components/blocks/buttons/ProjectOfferFileDownloadButton.tsx
+++ b/src/renderer/components/blocks/buttons/ProjectOfferFileDownloadButton.tsx
@@ -3,6 +3,8 @@ import { Button } from '@/components';
 import { AiOutlineDeliveredProcedure } from 'react-icons/ai';
 import { Alert } from 'flowbite-react';
 import { FormattedMessage } from 'react-intl';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/store';
 
 interface Props {
   disabled?: boolean;
@@ -11,6 +13,7 @@ interface Props {
 const ProjectOfferFileDownloadButton: React.FC<Props> = ({ disabled }) => {
   const [downloadLoading, setDownloadLoading] = useState(false);
   const [showDownLoadFailedAlert, setShowDownloadFailedAlert] = useState<boolean>(false);
+  const appStore = useSelector((state: RootState) => state.app);
 
   useEffect(() => {
     if (showDownLoadFailedAlert) {
@@ -33,9 +36,20 @@ const ProjectOfferFileDownloadButton: React.FC<Props> = ({ disabled }) => {
   const handleClickDownload = async () => {
     setDownloadLoading(true);
     try {
-      const url = new URL('http://localhost:31310/v1/offer');
+      const url = new URL(`${appStore.apiHost}/v1/offer`);
+      const headers = {
+        Accept: '*/*',
+      };
 
-      const downloadResponse: Response = await fetch(url);
+      if (appStore?.apiKey) {
+        headers['X-Api-Key'] = appStore.apiKey;
+      }
+
+      const downloadResponse: Response = await fetch(url, {
+        mode: 'cors',
+        headers,
+      });
+
       if (!downloadResponse?.ok) {
         setShowDownloadFailedAlert(true);
         return;

--- a/src/renderer/components/blocks/buttons/ProjectXlsUploadDownloadButtons.tsx
+++ b/src/renderer/components/blocks/buttons/ProjectXlsUploadDownloadButtons.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/components';
 import { useUploadProjectsXlsMutation } from '@/api';
 import { Alert } from 'flowbite-react';
 import { FormattedMessage } from 'react-intl';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/store';
 
 interface XlsUploadDownloadButtonsProps {
   orgUid: string;
@@ -20,6 +22,7 @@ const ProjectXlsUploadDownloadButtons: React.FC<XlsUploadDownloadButtonsProps> =
 }: XlsUploadDownloadButtonsProps) => {
   // upload hooks and state
   const [triggerUploadProjectXls] = useUploadProjectsXlsMutation();
+  const appStore = useSelector((state: RootState) => state.app);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [showUploadFailedAlert, setShowUploadFailedAlert] = useState<boolean>(false);
 
@@ -63,13 +66,25 @@ const ProjectXlsUploadDownloadButtons: React.FC<XlsUploadDownloadButtonsProps> =
   const handleClickDownload = async () => {
     setDownloadLoading(true);
     try {
-      const url = new URL('http://localhost:31310/v1/projects');
+      const url = new URL(`${appStore.apiHost}/v1/projects`);
       url.searchParams.append('xls', 'true');
       orgUid && url.searchParams.append('orgUid', orgUid);
       search && url.searchParams.append('search', search);
       order && url.searchParams.append('order', order);
 
-      const downloadResponse: Response = await fetch(url);
+      const headers = {
+        Accept: '*/*',
+      };
+
+      if (appStore?.apiKey) {
+        headers['X-Api-Key'] = appStore.apiKey;
+      }
+
+      const downloadResponse: Response = await fetch(url, {
+        mode: 'cors',
+        headers,
+      });
+
       if (!downloadResponse?.ok) {
         setShowDownloadFailedAlert(true);
         return;

--- a/src/renderer/components/blocks/buttons/UnitXlsUploadDownloadButtons.tsx
+++ b/src/renderer/components/blocks/buttons/UnitXlsUploadDownloadButtons.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/components';
 import { useUploadUnitsXlsMutation } from '@/api';
 import { Alert } from 'flowbite-react';
 import { FormattedMessage } from 'react-intl';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/store';
 
 interface XlsUploadDownloadButtonsProps {
   orgUid: string;
@@ -20,6 +22,7 @@ const UnitXlsUploadDownloadButtons: React.FC<XlsUploadDownloadButtonsProps> = ({
 }: XlsUploadDownloadButtonsProps) => {
   // upload hooks and state
   const [triggerUploadUnitXls] = useUploadUnitsXlsMutation();
+  const appStore = useSelector((state: RootState) => state.app);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [showUploadFailedAlert, setShowUploadFailedAlert] = useState<boolean>(false);
   const [downloadLoading, setDownloadLoading] = useState(false);
@@ -63,13 +66,25 @@ const UnitXlsUploadDownloadButtons: React.FC<XlsUploadDownloadButtonsProps> = ({
   const handleClickDownload = async () => {
     setDownloadLoading(true);
     try {
-      const url = new URL('http://localhost:31310/v1/units');
+      const url = new URL(`${appStore.apiHost}/v1/units`);
       url.searchParams.append('xls', 'true');
       orgUid && url.searchParams.append('orgUid', orgUid);
       search && url.searchParams.append('search', search);
       order && url.searchParams.append('order', order);
 
-      const downloadResponse: Response = await fetch(url);
+      const headers = {
+        Accept: '*/*',
+      };
+
+      if (appStore?.apiKey) {
+        headers['X-Api-Key'] = appStore.apiKey;
+      }
+
+      const downloadResponse: Response = await fetch(url, {
+        mode: 'cors',
+        headers,
+      });
+
       if (!downloadResponse?.ok) {
         setShowDownloadFailedAlert(true);
         return;


### PR DESCRIPTION
the download file button components now use the app state's apiHost instead of the hardcoded default host