### PR TITLE
fix: make connect modal work when running cadt on localhost

### DIFF
--- a/src/renderer/api/cadt/v1/system/system.api.ts
+++ b/src/renderer/api/cadt/v1/system/system.api.ts
@@ -52,10 +52,21 @@ const systemApi = cadtApi.injectEndpoints({
         method: 'GET',
       }),
       transformResponse(baseQueryReturnValue: BaseQueryResult<Config>): Config | undefined {
+        // Check if response is empty, null, or HTML content (which would indicate a 404 served as index.html)
         if (_.isEmpty(baseQueryReturnValue) || _.isNil(baseQueryReturnValue)) {
           return undefined;
         }
-        return baseQueryReturnValue;
+
+        if (typeof baseQueryReturnValue === 'string' && baseQueryReturnValue.includes('<!doctype html>')) {
+          return undefined;
+        }
+
+        // Ensure it's a valid config object with expected structure
+        if (typeof baseQueryReturnValue === 'object' && baseQueryReturnValue !== null) {
+          return baseQueryReturnValue as Config;
+        }
+
+        return undefined;
       },
     }),
     getThemeColors: builder.query<any, void>({
@@ -64,10 +75,19 @@ const systemApi = cadtApi.injectEndpoints({
         method: 'GET',
       }),
       transformResponse(baseQueryReturnValue: BaseQueryResult<any>): any {
-        if (_.isEmpty(baseQueryReturnValue) || _.isNil(baseQueryReturnValue)) {
+        // Check if response is empty, null, or HTML content (which would indicate a 404 served as index.html)
+        if (
+          _.isEmpty(baseQueryReturnValue) ||
+          _.isNil(baseQueryReturnValue) ||
+          (typeof baseQueryReturnValue === 'string' && baseQueryReturnValue.includes('<!doctype html>'))
+        ) {
           return undefined;
         }
-        return baseQueryReturnValue;
+        // Ensure it's a valid object
+        if (typeof baseQueryReturnValue === 'object' && baseQueryReturnValue !== null) {
+          return baseQueryReturnValue;
+        }
+        return undefined;
       },
     }),
   }),

--- a/src/renderer/components/blocks/buttons/ConnectButton.tsx
+++ b/src/renderer/components/blocks/buttons/ConnectButton.tsx
@@ -7,6 +7,7 @@ import { useGetHealthQuery } from '@/api/cadt/v1/system';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@/store';
 import { resetApiHost } from '@/store/slices/app';
+import { cadtApi } from '@/api/cadt/v1';
 
 const ConnectButton: React.FC = () => {
   const location = useLocation();
@@ -32,6 +33,13 @@ const ConnectButton: React.FC = () => {
 
   const handleDisconnect = () => {
     dispatch(resetApiHost());
+    // Clear persisted storage to prevent auto-reconnection
+    localStorage.removeItem('persist:app');
+    sessionStorage.removeItem('persist:app');
+
+    // Clear RTK Query cache to force fresh health check
+    dispatch(cadtApi.util.resetApiState());
+
     setTimeout(() => window.location.reload(), 0);
   };
 

--- a/src/renderer/store/slices/app/app.initialstate.ts
+++ b/src/renderer/store/slices/app/app.initialstate.ts
@@ -8,7 +8,7 @@ export interface AppState {
 
 const initialState: AppState = {
   locale: null,
-  apiHost: 'http://localhost:31310',
+  apiHost: '', // Empty string means no default API host
   apiKey: null,
   configFileLoaded: false,
   isDarkTheme: false,


### PR DESCRIPTION
With the default host set, if you have cadt running locally, you can never get the UI to disconnect to be able to reconnect to a different host.  There's not a great use case for this behavior and it makes development even more difficult.  Additionally, reset some caches when disconnecting from a host.  Plus, detect that a config file isn't the expected format more thoroughly.  